### PR TITLE
Add numbers to listed files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
-var EXTENSIONS = [
+var count = 0,
+    EXTENSIONS = [
         '.js',
         '.jsx',
         '.es',
@@ -10,7 +11,7 @@ var EXTENSIONS = [
     LOGGING_PROCESSOR = {
         preprocess: function(text, filename) {
             if (IS_LOGGING_ALLOWED) {
-                console.log('Linting ' + filename);
+                console.log(++count + '. Linting ' + filename);
             }
             return [text];
         },


### PR DESCRIPTION
Example:
```
1. Linting /workspace/my-package/index.js
2. Linting /workspace/my-package/instance.js
3. Linting /workspace/my-package/singleton.js
4. Linting /workspace/my-package/tests/child.js
5. Linting /workspace/my-package/tests/index.js
6. Linting /workspace/my-package/tests/instance.js
7. Linting /workspace/my-package/tests/missing-key.js
8. Linting /workspace/my-package/tests/singleton.js
9. Linting /workspace/my-package/tests/stubs.js
10. Linting /workspace/my-package/utils/get-something.js
11. Linting /workspace/my-package/utils/helper.js
12. Linting /workspace/my-package/utils/jsonclone.js
```

One use case where I can find this useful is just to see that an (automatic) upgrade in ESlint version did not reduce the number of files processed.