### PR TITLE
Remove base directory from output

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+var base = process.cwd();
+
 var count = 0,
     EXTENSIONS = [
         '.js',
@@ -11,7 +13,7 @@ var count = 0,
     LOGGING_PROCESSOR = {
         preprocess: function(text, filename) {
             if (IS_LOGGING_ALLOWED) {
-                console.log(++count + '. Linting ' + filename);
+                console.log(++count + '. Linting ' + filename.replace(base, ''));
             }
             return [text];
         },


### PR DESCRIPTION
Before:
```
1. Linting /workspace/my-package/index.js
2. Linting /workspace/my-package/instance.js
3. Linting /workspace/my-package/singleton.js
4. Linting /workspace/my-package/tests/child.js
5. Linting /workspace/my-package/tests/index.js
6. Linting /workspace/my-package/tests/instance.js
7. Linting /workspace/my-package/tests/missing-key.js
8. Linting /workspace/my-package/tests/singleton.js
9. Linting /workspace/my-package/tests/stubs.js
10. Linting /workspace/my-package/utils/get-something.js
11. Linting /workspace/my-package/utils/helper.js
12. Linting /workspace/my-package/utils/jsonclone.js
```
After:
```
1. Linting /index.js
2. Linting /instance.js
3. Linting /singleton.js
4. Linting /tests/child.js
5. Linting /tests/index.js
6. Linting /tests/instance.js
7. Linting /tests/missing-key.js
8. Linting /tests/singleton.js
9. Linting /tests/stubs.js
10. Linting /utils/get-something.js
11. Linting /utils/helper.js
12. Linting /utils/jsonclone.js
```

I feel this helps readability